### PR TITLE
Moved Labels from build stage to deploy stage in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,12 +49,12 @@ COPY --from=configure / /
 LABEL org.opencontainers.image.title="workspace" \
       org.opencontainers.image.description="A containerized virtual desktop environment with KasmVNC, Firefox, Jupyter, and VS Code Server for DTaaS" \
       org.opencontainers.image.vendor="INTO-CPS Association" \
-      org.opencontainers.image.authors="INTO-CPS Association" \
+      org.opencontainers.image.authors="[Prasad Talasila <prasad.talasila@ece.au.dk>, Aleksander Ross Møller <aleksander.r.m@protonmail.com>]" \
       org.opencontainers.image.url="https://github.com/INTO-CPS-Association/workspace" \
       org.opencontainers.image.source="https://github.com/INTO-CPS-Association/workspace" \
       org.opencontainers.image.documentation="https://github.com/INTO-CPS-Association/workspace/blob/main/README.md" \
-      org.opencontainers.image.licenses="GPL-3.0" \
-      org.opencontainers.image.version="1.0.0"
+      org.opencontainers.image.licenses="[https://github.com/INTO-CPS-Association/workspace/blob/main/LICENSE.md, https://github.com/kasmtech/workspaces-core-images/blob/release/1.18.0/LICENSE.md]" \
+      org.opencontainers.image.version="0.1.0"
 
 EXPOSE 8080
 


### PR DESCRIPTION
Labels were defined in build stage of Dockerfile and as such wasn't present in the final image as it is based on a deploy stage from scratch. This PR moves the label definitions to the deploy stage, making them present in the final image.