### PR TITLE
Added .gitattributes, specifying lf line endings for all non binary files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,26 @@
+# Force LF for all text files (this is a Linux/Docker project)
+* text eol=lf
+
+# Binary files - don't modify
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.zip binary
+*.tar binary
+*.tar.gz binary
+*.tgz binary
+*.gz binary
+*.bz2 binary
+*.xz binary
+*.7z binary
+*.pdf binary
+*.exe binary
+*.dll binary
+*.so binary
+*.dylib binary
+*.class binary
+*.jar binary
+*.war binary
+*.ear binary


### PR DESCRIPTION
When cloning the repository to a Windows based machine, lineendings for all files are converted from lf to crlf. This is a problem as most files are meant to run in a Linux context.

This PR adds a .gitattributes file, specifying that all text files must be checked out with lf line endings.
(It also designates which files are binary files, and should therefore not be modified.)