### PR TITLE
Replace su session change with privilege de-escalation within dtaas_shim.sh

### DIFF
--- a/workspaces/src/startup/dtaas_shim.sh
+++ b/workspaces/src/startup/dtaas_shim.sh
@@ -57,4 +57,5 @@ fi
 
 echo "Continuing KASM script chain: '$*'"
 echo -e "------------- END OF DTAAS SHIM SCRIPT --------------\n"
-exec su -m "${MAIN_USER}" -c "cd ${HOME}; exec $*"
+cd "${HOME}"
+exec setpriv --reuid=1000 --regid=1000 --init-groups -- "$@"

--- a/workspaces/src/startup/dtaas_shim.sh
+++ b/workspaces/src/startup/dtaas_shim.sh
@@ -58,4 +58,4 @@ fi
 echo "Continuing KASM script chain: '$*'"
 echo -e "------------- END OF DTAAS SHIM SCRIPT --------------\n"
 cd "${HOME}"
-exec setpriv --reuid=1000 --regid=1000 --init-groups -- "$@"
+exec setpriv --reuid="${MAIN_USER}" --regid="${MAIN_USER}" --init-groups -- "$@"


### PR DESCRIPTION
The script `dtaas_shim.sh` - used to set the main user and run nginx configuration at Docker startup before running the usual KASM startup scripts - used `su` to change from root to MAIN_USER and continue the startup script chain.

This resulted in all orphaned subprocesses not being properly reaped, as `su` would fork of before running the next script in the startup chain, remaining itself PID 1 without having the capability to manage the orphans that it would be handed as PID 1.

Thus, a lot of Zombies.

This PR remedies this, by de-escalating privileges to MAIN_USER's using `setpriv` and then exec'ing the next startup script, instead of running the next startup script inside a new user session with `su`.

This solves issue #76.