### PR TITLE
Disabled max body size check in nginx config

### DIFF
--- a/workspaces/src/resources/jupyter/jupyter_notebook_config.py
+++ b/workspaces/src/resources/jupyter/jupyter_notebook_config.py
@@ -9,16 +9,16 @@ c = get_config()  # noqa: F821 pylint: disable=undefined-variable
 jupyter_server_port = int(os.getenv("JUPYTER_SERVER_PORT"))
 
 # http connection config
-c.NotebookApp.ip = "0.0.0.0"
-c.NotebookApp.port = jupyter_server_port
-c.NotebookApp.root_dir = "/workspace"
-c.NotebookApp.allow_root = True
-c.NotebookApp.port_retries = 0
-c.NotebookApp.quit_button = False
-c.NotebookApp.allow_remote_access = True
-c.NotebookApp.disable_check_xsrf = True
-c.NotebookApp.allow_origin = "*"
-c.NotebookApp.trust_xheaders = True
+c.ServerApp.ip = "0.0.0.0"
+c.ServerApp.port = jupyter_server_port
+c.ServerApp.root_dir = "/workspace"
+c.ServerApp.allow_root = True
+c.ServerApp.port_retries = 0
+c.ServerApp.quit_button = False
+c.ServerApp.allow_remote_access = True
+c.ServerApp.disable_check_xsrf = True
+c.ServerApp.allow_origin = "*"
+c.ServerApp.trust_xheaders = True
 
 # ensure that Jupyter doesn't open a browser window on image startup
 c.NotebookApp.open_browser = False
@@ -29,10 +29,10 @@ c.ExtensionApp.open_browser = False
 # set base url if available
 base_url = "/" + os.getenv("MAIN_USER", "")
 if base_url is not None and base_url != "/":
-    c.NotebookApp.base_url = base_url
+    c.ServerApp.base_url = base_url
 
 # delete files fully when deleted
 c.FileContentsManager.delete_to_trash = False
 
 # deactivate token -> no authentication
-c.NotebookApp.token = ""
+c.IdentityProvider.token = ""

--- a/workspaces/src/startup/nginx.conf
+++ b/workspaces/src/startup/nginx.conf
@@ -28,6 +28,8 @@ http {
         scgi_temp_path /home/{MAIN_USER}/.nginx/temp/scgi;
         uwsgi_temp_path /home/{MAIN_USER}/.nginx/temp/uwsgi;
 
+        client_max_body_size 0;
+
         listen 8080;
 
         absolute_redirect off;

--- a/workspaces/src/startup/nginx.conf
+++ b/workspaces/src/startup/nginx.conf
@@ -37,7 +37,7 @@ http {
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
 
-            client_max_body_size 0;
+            client_max_body_size 500m;
 
             proxy_pass http://jupyter;
         }

--- a/workspaces/src/startup/nginx.conf
+++ b/workspaces/src/startup/nginx.conf
@@ -28,8 +28,6 @@ http {
         scgi_temp_path /home/{MAIN_USER}/.nginx/temp/scgi;
         uwsgi_temp_path /home/{MAIN_USER}/.nginx/temp/uwsgi;
 
-        client_max_body_size 0;
-
         listen 8080;
 
         absolute_redirect off;
@@ -38,6 +36,8 @@ http {
             proxy_http_version 1.1;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+
+            client_max_body_size 0;
 
             proxy_pass http://jupyter;
         }


### PR DESCRIPTION
This PR removes the max body size check on client requests going through the Nginx proxy, allowing for file uploads to Jupyter greater than the Nginx default value of 1MB.

This PR also updates the Jupyter config file with new config names that are not in danger of being deprecated soon.

This PR solves issue #81.